### PR TITLE
feat: added day 5 dashboard search and course workspace navigation

### DIFF
--- a/backend/routers/courses.py
+++ b/backend/routers/courses.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from urllib.parse import unquote
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
@@ -40,6 +41,21 @@ def get_courses():
         "success": True,
         "courses": _read_confirmed_courses(),
     }
+
+
+@router.get("/{course_code}")
+def get_course(course_code: str):
+    decoded_code = unquote(course_code).upper()
+    courses = _read_confirmed_courses()
+
+    for course in courses:
+        if course["code"].upper() == decoded_code:
+            return {
+                "success": True,
+                "course": course,
+            }
+
+    raise HTTPException(status_code=404, detail="Course not found.")
 
 
 @router.post("/confirm")

--- a/frontend/src/app/course/[courseId]/page.tsx
+++ b/frontend/src/app/course/[courseId]/page.tsx
@@ -1,13 +1,114 @@
-export default function CourseWorkspacePage({
-  params,
-}: {
-  params: Promise<{ courseId: string }>;
-}) {
+"use client";
+
+import { fetchCourseByCode } from "@/lib/api";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useEffect, useState } from "react";
+
+type Course = {
+  code: string;
+  title: string;
+  type: string;
+};
+
+export default function CoursePage() {
+  const params = useParams<{ courseId: string }>();
+  const [course, setCourse] = useState<Course | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    async function loadCourse() {
+      try {
+        const rawCourseId = params?.courseId;
+
+        if (!rawCourseId) {
+          setError("Course not found.");
+          return;
+        }
+
+        const decodedCourseId = decodeURIComponent(rawCourseId);
+        const result = await fetchCourseByCode(decodedCourseId);
+        setCourse(result.course || null);
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Failed to load course.";
+        setError(message);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadCourse();
+  }, [params]);
+
   return (
-    <div className="min-h-screen p-8">
-      <h1 className="text-3xl font-bold mb-4">Course Workspace</h1>
-      <p className="text-zinc-600">Notes, Materials, and Chat for this course.</p>
-      {/* TODO: Three-panel layout — Notes | Materials | Chat */}
+    <div className="min-h-screen bg-zinc-50 p-8">
+      <div className="mx-auto max-w-4xl">
+        <div className="mb-8">
+          <Link
+            href="/dashboard"
+            className="mb-2 inline-block text-sm text-zinc-500 hover:text-zinc-700"
+          >
+            ← Back to Dashboard
+          </Link>
+          <h1 className="text-3xl font-bold">Course Workspace</h1>
+          <p className="mt-2 text-zinc-600">
+            This is the course workspace shell for the selected course.
+          </p>
+        </div>
+
+        {loading && (
+          <div className="rounded-md border border-zinc-200 bg-white p-4 text-sm text-zinc-600">
+            Loading course...
+          </div>
+        )}
+
+        {error && (
+          <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        {!loading && !error && course && (
+          <div className="space-y-6">
+            <div className="rounded-lg border border-zinc-200 bg-white p-6 shadow-sm">
+              <div className="flex items-center justify-between">
+                <h2 className="text-2xl font-semibold text-zinc-900">
+                  {course.code}
+                </h2>
+                <span className="rounded-full bg-zinc-100 px-3 py-1 text-sm font-medium text-zinc-700">
+                  {course.type}
+                </span>
+              </div>
+              <p className="mt-3 text-zinc-600">{course.title}</p>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-3">
+              <div className="rounded-lg border border-zinc-200 bg-white p-5">
+                <h3 className="text-lg font-semibold">Lecture Notes</h3>
+                <p className="mt-2 text-sm text-zinc-600">
+                  Placeholder panel for lecture notes.
+                </p>
+              </div>
+
+              <div className="rounded-lg border border-zinc-200 bg-white p-5">
+                <h3 className="text-lg font-semibold">Slides & Documents</h3>
+                <p className="mt-2 text-sm text-zinc-600">
+                  Placeholder panel for course materials.
+                </p>
+              </div>
+
+              <div className="rounded-lg border border-zinc-200 bg-white p-5">
+                <h3 className="text-lg font-semibold">AI Chatbot</h3>
+                <p className="mt-2 text-sm text-zinc-600">
+                  Placeholder panel for course-specific AI chat.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { fetchConfirmedCourses } from "@/lib/api";
-import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
 
 type Course = {
   code: string;
@@ -13,6 +14,7 @@ export default function DashboardPage() {
   const [courses, setCourses] = useState<Course[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [query, setQuery] = useState("");
 
   useEffect(() => {
     async function loadCourses() {
@@ -31,6 +33,19 @@ export default function DashboardPage() {
     loadCourses();
   }, []);
 
+  const filteredCourses = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return courses;
+
+    return courses.filter((course) => {
+      return (
+        course.code.toLowerCase().includes(q) ||
+        course.title.toLowerCase().includes(q) ||
+        course.type.toLowerCase().includes(q)
+      );
+    });
+  }, [courses, query]);
+
   return (
     <div className="min-h-screen bg-zinc-50 p-8">
       <div className="mx-auto max-w-5xl">
@@ -39,6 +54,16 @@ export default function DashboardPage() {
           <p className="mt-2 text-zinc-600">
             Your confirmed course list is shown below.
           </p>
+        </div>
+
+        <div className="mb-6">
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search by course code, title, or type"
+            className="w-full rounded-md border border-zinc-300 bg-white px-4 py-3 text-sm focus:border-zinc-500 focus:outline-none"
+          />
         </div>
 
         {loading && (
@@ -53,18 +78,19 @@ export default function DashboardPage() {
           </div>
         )}
 
-        {!loading && !error && courses.length === 0 && (
+        {!loading && !error && filteredCourses.length === 0 && (
           <div className="rounded-md border border-zinc-200 bg-white p-4 text-sm text-zinc-600">
-            No confirmed courses found yet.
+            No matching courses found.
           </div>
         )}
 
-        {!loading && !error && courses.length > 0 && (
+        {!loading && !error && filteredCourses.length > 0 && (
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {courses.map((course, index) => (
-              <div
+            {filteredCourses.map((course, index) => (
+              <Link
                 key={`${course.code}-${index}`}
-                className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm"
+                href={`/course/${encodeURIComponent(course.code)}`}
+                className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm transition hover:border-zinc-400 hover:shadow"
               >
                 <div className="flex items-center justify-between">
                   <h2 className="text-lg font-semibold text-zinc-900">{course.code}</h2>
@@ -73,7 +99,8 @@ export default function DashboardPage() {
                   </span>
                 </div>
                 <p className="mt-2 text-sm text-zinc-600">{course.title || "Untitled course"}</p>
-              </div>
+                <p className="mt-4 text-xs font-medium text-zinc-500">Open workspace →</p>
+              </Link>
             ))}
           </div>
         )}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -26,7 +26,7 @@ export async function parseRoutine(file: File): Promise<ParseResponse> {
         message = errorData.detail;
       }
     } catch {
-      // ignore json parse error
+      // ignore
     }
 
     throw new Error(message);
@@ -69,6 +69,31 @@ export async function fetchConfirmedCourses() {
 
   if (!response.ok) {
     throw new Error("Failed to fetch confirmed courses.");
+  }
+
+  return response.json();
+}
+
+export async function fetchCourseByCode(courseCode: string) {
+  const encoded = encodeURIComponent(courseCode);
+
+  const response = await fetch(`${BASE_URL}/api/v1/courses/${encoded}`, {
+    method: "GET",
+  });
+
+  if (!response.ok) {
+    let message = "Failed to fetch course.";
+
+    try {
+      const errorData = await response.json();
+      if (errorData?.detail) {
+        message = errorData.detail;
+      }
+    } catch {
+      // ignore
+    }
+
+    throw new Error(message);
   }
 
   return response.json();


### PR DESCRIPTION
## Summary
Implements Day 5 dashboard and course workspace navigation flow.

## What was added

### Contributor B — Day 5B
- Added single-course fetch endpoint: `GET /api/v1/courses/{course_code}`

### Contributor A — Day 5A
- Added searchable dashboard for confirmed courses
- Made dashboard course cards clickable
- Added dynamic course workspace route: `/course/[courseId]`
- Loaded selected course data from backend into the course workspace shell

## What was tested
- confirmed courses load correctly on dashboard
- dashboard search filters by code/title/type
- clicking a course card opens its workspace page
- saved course data is fetched correctly by course code

## Notes
- persistence remains lightweight JSON-based for now
- course workspace panels are currently placeholders for later expansion