### PR TITLE
feat: add workspace api stubs for notes materials and chat

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from routers import workspace
 from fastapi.middleware.cors import CORSMiddleware
 
 from config import get_settings
@@ -41,3 +42,4 @@ def health_check():
 
 app.include_router(routine_router)
 app.include_router(courses_router)
+app.include_router(workspace.router)

--- a/backend/models/workspace.py
+++ b/backend/models/workspace.py
@@ -1,0 +1,53 @@
+from pydantic import BaseModel
+from typing import List
+
+
+class NoteStub(BaseModel):
+    id: str
+    course_code: str
+    title: str
+    content: str
+    updated_at: str
+
+
+class MaterialStub(BaseModel):
+    id: str
+    course_code: str
+    filename: str
+    file_type: str
+    status: str
+
+
+class ChatMessageStub(BaseModel):
+    id: str
+    role: str
+    content: str
+    created_at: str
+
+
+class NotesResponse(BaseModel):
+    success: bool = True
+    course_code: str
+    notes: List[NoteStub]
+
+
+class MaterialsResponse(BaseModel):
+    success: bool = True
+    course_code: str
+    materials: List[MaterialStub]
+
+
+class ChatResponse(BaseModel):
+    success: bool = True
+    course_code: str
+    messages: List[ChatMessageStub]
+
+
+class WorkspaceOverviewResponse(BaseModel):
+    success: bool = True
+    course_code: str
+    header_title: str
+    header_subtitle: str
+    notes_enabled: bool = True
+    materials_enabled: bool = True
+    chat_enabled: bool = True

--- a/backend/routers/workspace.py
+++ b/backend/routers/workspace.py
@@ -1,0 +1,73 @@
+from fastapi import APIRouter
+from models.workspace import (
+    NotesResponse,
+    MaterialsResponse,
+    ChatResponse,
+    WorkspaceOverviewResponse,
+)
+
+router = APIRouter(prefix="/api/v1/workspace", tags=["Workspace"])
+
+
+@router.get("/{course_code}", response_model=WorkspaceOverviewResponse)
+def get_workspace_overview(course_code: str):
+    normalized = course_code.upper().strip()
+
+    return WorkspaceOverviewResponse(
+        course_code=normalized,
+        header_title=f"{normalized} Workspace",
+        header_subtitle="Notes, materials, and AI chat will appear here."
+    )
+
+
+@router.get("/{course_code}/notes", response_model=NotesResponse)
+def get_notes_stub(course_code: str):
+    normalized = course_code.upper().strip()
+
+    return NotesResponse(
+        course_code=normalized,
+        notes=[
+            {
+                "id": "note-1",
+                "course_code": normalized,
+                "title": "Sample Note",
+                "content": "This is a placeholder note panel for Day 6.",
+                "updated_at": "2026-03-19 10:00 AM",
+            }
+        ],
+    )
+
+
+@router.get("/{course_code}/materials", response_model=MaterialsResponse)
+def get_materials_stub(course_code: str):
+    normalized = course_code.upper().strip()
+
+    return MaterialsResponse(
+        course_code=normalized,
+        materials=[
+            {
+                "id": "material-1",
+                "course_code": normalized,
+                "filename": "No uploaded file yet",
+                "file_type": "placeholder",
+                "status": "pending-day-8",
+            }
+        ],
+    )
+
+
+@router.get("/{course_code}/chat", response_model=ChatResponse)
+def get_chat_stub(course_code: str):
+    normalized = course_code.upper().strip()
+
+    return ChatResponse(
+        course_code=normalized,
+        messages=[
+            {
+                "id": "msg-1",
+                "role": "assistant",
+                "content": "Chat endpoint stub is ready. Real chat starts on Day 10.",
+                "created_at": "2026-03-19 10:00 AM",
+            }
+        ],
+    )


### PR DESCRIPTION
## Summary
Implements Day 6B backend workspace API stubs.

## What was added
- added workspace overview endpoint
- added notes endpoint stub
- added materials endpoint stub
- added chat endpoint stub
- added workspace response models

## What was tested
- backend starts without import error
- `/api/v1/workspace/CSE3219` returns workspace header JSON
- `/api/v1/workspace/CSE3219/notes` returns notes array
- `/api/v1/workspace/CSE3219/materials` returns materials array
- `/api/v1/workspace/CSE3219/chat` returns messages array