### PR TITLE
feat: build course workspace shell with three panel layout

### DIFF
--- a/frontend/src/app/course/[courseId]/page.tsx
+++ b/frontend/src/app/course/[courseId]/page.tsx
@@ -1,113 +1,163 @@
 "use client";
 
-import { fetchCourseByCode } from "@/lib/api";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
+import {
+  fetchWorkspaceChat,
+  fetchWorkspaceMaterials,
+  fetchWorkspaceNotes,
+  fetchWorkspaceOverview,
+  type ChatMessageStub,
+  type MaterialStub,
+  type NoteStub,
+  type WorkspaceOverview,
+} from "../../../lib/workspace-api";
 
-type Course = {
-  code: string;
-  title: string;
-  type: string;
-};
-
-export default function CoursePage() {
+export default function CourseWorkspacePage() {
   const params = useParams<{ courseId: string }>();
-  const [course, setCourse] = useState<Course | null>(null);
+  const courseId = params?.courseId ? decodeURIComponent(params.courseId) : "";
+
+  const [overview, setOverview] = useState<WorkspaceOverview | null>(null);
+  const [notes, setNotes] = useState<NoteStub[]>([]);
+  const [materials, setMaterials] = useState<MaterialStub[]>([]);
+  const [messages, setMessages] = useState<ChatMessageStub[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
   useEffect(() => {
-    async function loadCourse() {
+    async function loadWorkspace() {
       try {
-        const rawCourseId = params?.courseId;
+        setLoading(true);
+        setError("");
 
-        if (!rawCourseId) {
-          setError("Course not found.");
-          return;
-        }
+        const [overviewData, notesData, materialsData, chatData] = await Promise.all([
+          fetchWorkspaceOverview(courseId),
+          fetchWorkspaceNotes(courseId),
+          fetchWorkspaceMaterials(courseId),
+          fetchWorkspaceChat(courseId),
+        ]);
 
-        const decodedCourseId = decodeURIComponent(rawCourseId);
-        const result = await fetchCourseByCode(decodedCourseId);
-        setCourse(result.course || null);
+        setOverview(overviewData);
+        setNotes(notesData);
+        setMaterials(materialsData);
+        setMessages(chatData);
       } catch (err) {
         const message =
-          err instanceof Error ? err.message : "Failed to load course.";
+          err instanceof Error ? err.message : "Failed to load workspace.";
         setError(message);
       } finally {
         setLoading(false);
       }
     }
 
-    loadCourse();
-  }, [params]);
+    if (courseId) {
+      loadWorkspace();
+    }
+  }, [courseId]);
+
+  if (loading) {
+    return <div className="p-6">Loading workspace...</div>;
+  }
+
+  if (error) {
+    return <div className="p-6 text-red-600">{error}</div>;
+  }
 
   return (
-    <div className="min-h-screen bg-zinc-50 p-8">
-      <div className="mx-auto max-w-4xl">
-        <div className="mb-8">
-          <Link
-            href="/dashboard"
-            className="mb-2 inline-block text-sm text-zinc-500 hover:text-zinc-700"
-          >
-            ← Back to Dashboard
-          </Link>
-          <h1 className="text-3xl font-bold">Course Workspace</h1>
+    <div className="min-h-screen bg-zinc-50 p-6">
+      <div className="mx-auto max-w-7xl">
+        <Link
+          href="/dashboard"
+          className="mb-4 inline-block text-sm text-zinc-600 hover:text-zinc-900"
+        >
+          ← Back to Dashboard
+        </Link>
+
+        <div className="mb-6 rounded-xl border border-zinc-200 bg-white p-6 shadow-sm">
+          <h1 className="text-3xl font-bold text-zinc-900">
+            {overview?.header_title || `${courseId} Workspace`}
+          </h1>
           <p className="mt-2 text-zinc-600">
-            This is the course workspace shell for the selected course.
+            {overview?.header_subtitle || "Course workspace shell"}
           </p>
         </div>
 
-        {loading && (
-          <div className="rounded-md border border-zinc-200 bg-white p-4 text-sm text-zinc-600">
-            Loading course...
-          </div>
-        )}
-
-        {error && (
-          <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
-            {error}
-          </div>
-        )}
-
-        {!loading && !error && course && (
-          <div className="space-y-6">
-            <div className="rounded-lg border border-zinc-200 bg-white p-6 shadow-sm">
-              <div className="flex items-center justify-between">
-                <h2 className="text-2xl font-semibold text-zinc-900">
-                  {course.code}
-                </h2>
-                <span className="rounded-full bg-zinc-100 px-3 py-1 text-sm font-medium text-zinc-700">
-                  {course.type}
-                </span>
-              </div>
-              <p className="mt-3 text-zinc-600">{course.title}</p>
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+          <section className="rounded-xl border border-zinc-200 bg-white p-5 shadow-sm">
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="text-xl font-semibold">Lecture Notes</h2>
+              <span className="rounded-full bg-zinc-100 px-3 py-1 text-xs text-zinc-700">
+                Day 6 Shell
+              </span>
             </div>
 
-            <div className="grid gap-4 md:grid-cols-3">
-              <div className="rounded-lg border border-zinc-200 bg-white p-5">
-                <h3 className="text-lg font-semibold">Lecture Notes</h3>
-                <p className="mt-2 text-sm text-zinc-600">
-                  Placeholder panel for lecture notes.
-                </p>
-              </div>
-
-              <div className="rounded-lg border border-zinc-200 bg-white p-5">
-                <h3 className="text-lg font-semibold">Slides & Documents</h3>
-                <p className="mt-2 text-sm text-zinc-600">
-                  Placeholder panel for course materials.
-                </p>
-              </div>
-
-              <div className="rounded-lg border border-zinc-200 bg-white p-5">
-                <h3 className="text-lg font-semibold">AI Chatbot</h3>
-                <p className="mt-2 text-sm text-zinc-600">
-                  Placeholder panel for course-specific AI chat.
-                </p>
-              </div>
+            <div className="space-y-3">
+              {notes.map((note) => (
+                <div key={note.id} className="rounded-lg border border-zinc-200 p-3">
+                  <h3 className="font-medium text-zinc-900">{note.title}</h3>
+                  <p className="mt-2 text-sm text-zinc-600">{note.content}</p>
+                  <p className="mt-2 text-xs text-zinc-400">
+                    Updated: {note.updated_at}
+                  </p>
+                </div>
+              ))}
             </div>
-          </div>
-        )}
+
+            <div className="mt-4 rounded-lg border border-dashed border-zinc-300 p-3 text-sm text-zinc-500">
+              Note create/edit/save comes on Day 7.
+            </div>
+          </section>
+
+          <section className="rounded-xl border border-zinc-200 bg-white p-5 shadow-sm">
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="text-xl font-semibold">Slides & Documents</h2>
+              <span className="rounded-full bg-zinc-100 px-3 py-1 text-xs text-zinc-700">
+                Placeholder
+              </span>
+            </div>
+
+            <div className="space-y-3">
+              {materials.map((item) => (
+                <div key={item.id} className="rounded-lg border border-zinc-200 p-3">
+                  <p className="font-medium text-zinc-900">{item.filename}</p>
+                  <p className="mt-1 text-sm text-zinc-600">
+                    Type: {item.file_type}
+                  </p>
+                  <p className="mt-1 text-xs text-zinc-400">
+                    Status: {item.status}
+                  </p>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-4 rounded-lg border border-dashed border-zinc-300 p-3 text-sm text-zinc-500">
+              Material upload/list logic comes on Day 8.
+            </div>
+          </section>
+
+          <section className="rounded-xl border border-zinc-200 bg-white p-5 shadow-sm">
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="text-xl font-semibold">AI Chatbot</h2>
+              <span className="rounded-full bg-zinc-100 px-3 py-1 text-xs text-zinc-700">
+                Stub
+              </span>
+            </div>
+
+            <div className="space-y-3">
+              {messages.map((msg) => (
+                <div key={msg.id} className="rounded-lg bg-zinc-100 p-3">
+                  <p className="text-sm font-medium text-zinc-700">{msg.role}</p>
+                  <p className="mt-1 text-sm text-zinc-900">{msg.content}</p>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-4 rounded-lg border border-dashed border-zinc-300 p-3 text-sm text-zinc-500">
+              Real chat starts on Day 10.
+            </div>
+          </section>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/lib/workspace-api.ts
+++ b/frontend/src/lib/workspace-api.ts
@@ -1,0 +1,85 @@
+const BASE_URL = "http://127.0.0.1:8000";
+
+export type WorkspaceOverview = {
+  success: boolean;
+  course_code: string;
+  header_title: string;
+  header_subtitle: string;
+  notes_enabled: boolean;
+  materials_enabled: boolean;
+  chat_enabled: boolean;
+};
+
+export type NoteStub = {
+  id: string;
+  course_code: string;
+  title: string;
+  content: string;
+  updated_at: string;
+};
+
+export type MaterialStub = {
+  id: string;
+  course_code: string;
+  filename: string;
+  file_type: string;
+  status: string;
+};
+
+export type ChatMessageStub = {
+  id: string;
+  role: string;
+  content: string;
+  created_at: string;
+};
+
+export async function fetchWorkspaceOverview(courseCode: string): Promise<WorkspaceOverview> {
+  const response = await fetch(
+    `${BASE_URL}/api/v1/workspace/${encodeURIComponent(courseCode)}`
+  );
+
+  if (!response.ok) {
+    throw new Error("Failed to load workspace overview.");
+  }
+
+  return response.json();
+}
+
+export async function fetchWorkspaceNotes(courseCode: string): Promise<NoteStub[]> {
+  const response = await fetch(
+    `${BASE_URL}/api/v1/workspace/${encodeURIComponent(courseCode)}/notes`
+  );
+
+  if (!response.ok) {
+    throw new Error("Failed to load notes panel.");
+  }
+
+  const data = await response.json();
+  return data.notes || [];
+}
+
+export async function fetchWorkspaceMaterials(courseCode: string): Promise<MaterialStub[]> {
+  const response = await fetch(
+    `${BASE_URL}/api/v1/workspace/${encodeURIComponent(courseCode)}/materials`
+  );
+
+  if (!response.ok) {
+    throw new Error("Failed to load materials panel.");
+  }
+
+  const data = await response.json();
+  return data.materials || [];
+}
+
+export async function fetchWorkspaceChat(courseCode: string): Promise<ChatMessageStub[]> {
+  const response = await fetch(
+    `${BASE_URL}/api/v1/workspace/${encodeURIComponent(courseCode)}/chat`
+  );
+
+  if (!response.ok) {
+    throw new Error("Failed to load chat panel.");
+  }
+
+  const data = await response.json();
+  return data.messages || [];
+}


### PR DESCRIPTION
## Summary
Implements Day 6A frontend course workspace shell.

## What was added
- added course workspace header
- added notes panel structure
- added placeholder materials panel
- added chatbot stub panel
- added workspace API client helpers
- added stable back-to-dashboard navigation

## What was tested
- `/course/CSE3219` page opens
- header loads from backend
- notes panel shows sample note
- materials panel shows placeholder item
- chatbot panel shows stub message
- layout remains stable on refresh
- back-to-dashboard link works