### PR TITLE
feat: add notes api with firebase firestore persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,5 @@ temp/
 # Custom ML experiments (do not commit)
 backend/custom_cell_classifier/
 backend/requirements-custom-ml.txt
+
+backend/config/firebase_service_account.json

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from routers import workspace
+from routers import notes
 from fastapi.middleware.cors import CORSMiddleware
 
 from config import get_settings
@@ -43,3 +44,4 @@ def health_check():
 app.include_router(routine_router)
 app.include_router(courses_router)
 app.include_router(workspace.router)
+app.include_router(notes.router)

--- a/backend/models/notes.py
+++ b/backend/models/notes.py
@@ -1,0 +1,39 @@
+# backend/models/notes.py
+
+from pydantic import BaseModel, Field
+from typing import List
+
+
+class NoteCreateRequest(BaseModel):
+    course_code: str = Field(..., min_length=6)
+    title: str = Field(..., min_length=1, max_length=120)
+    content: str = Field(..., min_length=1)
+
+
+class NoteUpdateRequest(BaseModel):
+    title: str = Field(..., min_length=1, max_length=120)
+    content: str = Field(..., min_length=1)
+
+
+class NoteItem(BaseModel):
+    id: str
+    course_code: str
+    title: str
+    content: str
+    updated_at: str
+
+
+class NoteListResponse(BaseModel):
+    success: bool = True
+    course_code: str
+    notes: List[NoteItem]
+
+
+class NoteSingleResponse(BaseModel):
+    success: bool = True
+    note: NoteItem
+
+
+class NoteDeleteResponse(BaseModel):
+    success: bool = True
+    message: str

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ pillow==10.4.0
 pytesseract==0.3.13
 opencv-python==4.10.0.84
 numpy==2.1.1
+firebase-admin

--- a/backend/routers/notes.py
+++ b/backend/routers/notes.py
@@ -1,0 +1,108 @@
+# backend/routers/notes.py
+
+from datetime import datetime
+
+from fastapi import APIRouter, HTTPException
+from google.cloud.firestore_v1.base_query import FieldFilter
+
+from models.notes import (
+    NoteCreateRequest,
+    NoteUpdateRequest,
+    NoteListResponse,
+    NoteSingleResponse,
+    NoteDeleteResponse,
+)
+from services.firebase_admin_init import db
+
+router = APIRouter(prefix="/api/v1/notes", tags=["Notes"])
+
+NOTES_COLLECTION = "courseNotes"
+
+
+def now_string():
+    return datetime.now().strftime("%Y-%m-%d %I:%M %p")
+
+
+@router.get("/{course_code}", response_model=NoteListResponse)
+def get_notes_by_course(course_code: str):
+    notes_ref = db.collection(NOTES_COLLECTION)
+    query = notes_ref.where(filter=FieldFilter("course_code", "==", course_code))
+    docs = query.stream()
+
+    notes = []
+    for doc in docs:
+        data = doc.to_dict()
+        notes.append({
+            "id": doc.id,
+            "course_code": data["course_code"],
+            "title": data["title"],
+            "content": data["content"],
+            "updated_at": data["updated_at"],
+        })
+
+    notes.sort(key=lambda x: x["updated_at"], reverse=True)
+
+    return NoteListResponse(
+        course_code=course_code,
+        notes=notes,
+    )
+
+
+@router.post("", response_model=NoteSingleResponse)
+def create_note(payload: NoteCreateRequest):
+    new_note = {
+        "course_code": payload.course_code.strip(),
+        "title": payload.title.strip(),
+        "content": payload.content.strip(),
+        "updated_at": now_string(),
+    }
+
+    doc_ref = db.collection(NOTES_COLLECTION).document()
+    doc_ref.set(new_note)
+
+    return NoteSingleResponse(
+        note={
+            "id": doc_ref.id,
+            **new_note
+        }
+    )
+
+
+@router.put("/{note_id}", response_model=NoteSingleResponse)
+def update_note(note_id: str, payload: NoteUpdateRequest):
+    doc_ref = db.collection(NOTES_COLLECTION).document(note_id)
+    doc = doc_ref.get()
+
+    if not doc.exists:
+        raise HTTPException(status_code=404, detail="Note not found.")
+
+    existing = doc.to_dict()
+
+    updated_note = {
+        "course_code": existing["course_code"],
+        "title": payload.title.strip(),
+        "content": payload.content.strip(),
+        "updated_at": now_string(),
+    }
+
+    doc_ref.set(updated_note)
+
+    return NoteSingleResponse(
+        note={
+            "id": note_id,
+            **updated_note
+        }
+    )
+
+
+@router.delete("/{note_id}", response_model=NoteDeleteResponse)
+def delete_note(note_id: str):
+    doc_ref = db.collection(NOTES_COLLECTION).document(note_id)
+    doc = doc_ref.get()
+
+    if not doc.exists:
+        raise HTTPException(status_code=404, detail="Note not found.")
+
+    doc_ref.delete()
+
+    return NoteDeleteResponse(message="Note deleted successfully.")

--- a/backend/services/firebase_admin_init.py
+++ b/backend/services/firebase_admin_init.py
@@ -1,0 +1,14 @@
+# backend/services/firebase_admin_init.py
+
+from pathlib import Path
+import firebase_admin
+from firebase_admin import credentials, firestore
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+SERVICE_ACCOUNT_PATH = BASE_DIR / "config" / "firebase_service_account.json"
+
+if not firebase_admin._apps:
+    cred = credentials.Certificate(str(SERVICE_ACCOUNT_PATH))
+    firebase_admin.initialize_app(cred)
+
+db = firestore.client()


### PR DESCRIPTION
## Summary
Implements Day 7B backend notes module.

## What was implemented
- added notes CRUD API
- added Firebase Firestore persistence for notes
- added per-course note retrieval
- added Pydantic validation for note title and content
- connected note storage to course-specific documents

## Endpoints
- GET /api/v1/notes/{course_code}
- POST /api/v1/notes
- PUT /api/v1/notes/{note_id}
- DELETE /api/v1/notes/{note_id}

## What was tested
- create note through POST endpoint
- fetch notes by course code
- update note by note id
- delete note by note id
- validation rejects invalid empty fields
- note data remains available after backend restart

## CRUD test evidence
- attached Postman / Swagger screenshots for POST, GET, PUT, DELETE
- attached Firebase Firestore screenshots showing saved notes

## Known limitations
- updated_at is currently stored as formatted text
- authentication is not added yet
- notes are course-bound but not yet user-bound