### PR TITLE
feat: add notes UI with create view edit delete flow

### DIFF
--- a/frontend/src/app/course/[courseId]/page.tsx
+++ b/frontend/src/app/course/[courseId]/page.tsx
@@ -1,29 +1,40 @@
 "use client";
 
-import Link from "next/link";
-import { useParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import {
+  createNote,
+  deleteNote,
+  fetchNotesByCourse,
+  updateNote,
+  type NoteItem,
+} from "@/lib/notes-api";
 import {
   fetchWorkspaceChat,
   fetchWorkspaceMaterials,
-  fetchWorkspaceNotes,
   fetchWorkspaceOverview,
   type ChatMessageStub,
   type MaterialStub,
-  type NoteStub,
   type WorkspaceOverview,
-} from "../../../lib/workspace-api";
+} from "@/lib/workspace-api";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useEffect, useState } from "react";
 
 export default function CourseWorkspacePage() {
   const params = useParams<{ courseId: string }>();
   const courseId = params?.courseId ? decodeURIComponent(params.courseId) : "";
 
   const [overview, setOverview] = useState<WorkspaceOverview | null>(null);
-  const [notes, setNotes] = useState<NoteStub[]>([]);
+  const [notes, setNotes] = useState<NoteItem[]>([]);
   const [materials, setMaterials] = useState<MaterialStub[]>([]);
   const [messages, setMessages] = useState<ChatMessageStub[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+
+  const [noteTitle, setNoteTitle] = useState("");
+  const [noteContent, setNoteContent] = useState("");
+  const [editingNoteId, setEditingNoteId] = useState<string | null>(null);
+  const [savingNote, setSavingNote] = useState(false);
+  const [noteError, setNoteError] = useState("");
 
   useEffect(() => {
     async function loadWorkspace() {
@@ -33,7 +44,7 @@ export default function CourseWorkspacePage() {
 
         const [overviewData, notesData, materialsData, chatData] = await Promise.all([
           fetchWorkspaceOverview(courseId),
-          fetchWorkspaceNotes(courseId),
+          fetchNotesByCourse(courseId),
           fetchWorkspaceMaterials(courseId),
           fetchWorkspaceChat(courseId),
         ]);
@@ -55,6 +66,78 @@ export default function CourseWorkspacePage() {
       loadWorkspace();
     }
   }, [courseId]);
+
+  async function reloadNotes() {
+    const refreshed = await fetchNotesByCourse(courseId);
+    setNotes(refreshed);
+  }
+
+  async function handleSaveNote() {
+    if (!courseId) return;
+
+    const trimmedTitle = noteTitle.trim();
+    const trimmedContent = noteContent.trim();
+
+    if (!trimmedTitle || !trimmedContent) {
+      setNoteError("Title and content are required.");
+      return;
+    }
+
+    try {
+      setSavingNote(true);
+      setNoteError("");
+
+      if (editingNoteId) {
+        await updateNote(editingNoteId, trimmedTitle, trimmedContent);
+      } else {
+        await createNote(courseId, trimmedTitle, trimmedContent);
+      }
+
+      setNoteTitle("");
+      setNoteContent("");
+      setEditingNoteId(null);
+
+      await reloadNotes();
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to save note.";
+      setNoteError(message);
+    } finally {
+      setSavingNote(false);
+    }
+  }
+
+  function handleEditNote(note: NoteItem) {
+    setEditingNoteId(note.id);
+    setNoteTitle(note.title);
+    setNoteContent(note.content);
+    setNoteError("");
+  }
+
+  async function handleDeleteNote(noteId: string) {
+    try {
+      await deleteNote(noteId);
+
+      if (editingNoteId === noteId) {
+        setEditingNoteId(null);
+        setNoteTitle("");
+        setNoteContent("");
+      }
+
+      await reloadNotes();
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to delete note.";
+      setNoteError(message);
+    }
+  }
+
+  function handleCancelEdit() {
+    setEditingNoteId(null);
+    setNoteTitle("");
+    setNoteContent("");
+    setNoteError("");
+  }
 
   if (loading) {
     return <div className="p-6">Loading workspace...</div>;
@@ -87,25 +170,91 @@ export default function CourseWorkspacePage() {
           <section className="rounded-xl border border-zinc-200 bg-white p-5 shadow-sm">
             <div className="mb-4 flex items-center justify-between">
               <h2 className="text-xl font-semibold">Lecture Notes</h2>
-              <span className="rounded-full bg-zinc-100 px-3 py-1 text-xs text-zinc-700">
-                Day 6 Shell
+              <span className="rounded-full bg-green-100 px-3 py-1 text-xs text-green-700">
+                Day 7 Active
               </span>
             </div>
 
             <div className="space-y-3">
-              {notes.map((note) => (
-                <div key={note.id} className="rounded-lg border border-zinc-200 p-3">
-                  <h3 className="font-medium text-zinc-900">{note.title}</h3>
-                  <p className="mt-2 text-sm text-zinc-600">{note.content}</p>
-                  <p className="mt-2 text-xs text-zinc-400">
-                    Updated: {note.updated_at}
-                  </p>
+              <input
+                type="text"
+                placeholder="Note title"
+                value={noteTitle}
+                onChange={(e) => setNoteTitle(e.target.value)}
+                className="w-full rounded-lg border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-500"
+              />
+
+              <textarea
+                placeholder="Write your note here..."
+                value={noteContent}
+                onChange={(e) => setNoteContent(e.target.value)}
+                rows={6}
+                className="w-full rounded-lg border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-500"
+              />
+
+              {noteError && (
+                <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+                  {noteError}
                 </div>
-              ))}
+              )}
+
+              <div className="flex gap-2">
+                <button
+                  onClick={handleSaveNote}
+                  disabled={savingNote}
+                  className="rounded-lg bg-zinc-900 px-4 py-2 text-sm text-white hover:bg-zinc-700 disabled:opacity-60"
+                >
+                  {savingNote
+                    ? "Saving..."
+                    : editingNoteId
+                    ? "Update Note"
+                    : "Create Note"}
+                </button>
+
+                {editingNoteId && (
+                  <button
+                    onClick={handleCancelEdit}
+                    className="rounded-lg border border-zinc-300 px-4 py-2 text-sm text-zinc-700 hover:bg-zinc-100"
+                  >
+                    Cancel
+                  </button>
+                )}
+              </div>
             </div>
 
-            <div className="mt-4 rounded-lg border border-dashed border-zinc-300 p-3 text-sm text-zinc-500">
-              Note create/edit/save comes on Day 7.
+            <div className="mt-6 space-y-3">
+              {notes.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-zinc-300 p-3 text-sm text-zinc-500">
+                  No notes created for this course yet.
+                </div>
+              ) : (
+                notes.map((note) => (
+                  <div key={note.id} className="rounded-lg border border-zinc-200 p-3">
+                    <h3 className="font-medium text-zinc-900">{note.title}</h3>
+                    <p className="mt-2 whitespace-pre-wrap text-sm text-zinc-600">
+                      {note.content}
+                    </p>
+                    <p className="mt-2 text-xs text-zinc-400">
+                      Updated: {note.updated_at}
+                    </p>
+
+                    <div className="mt-3 flex gap-2">
+                      <button
+                        onClick={() => handleEditNote(note)}
+                        className="rounded-md border border-zinc-300 px-3 py-1 text-sm text-zinc-700 hover:bg-zinc-100"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        onClick={() => handleDeleteNote(note.id)}
+                        className="rounded-md border border-red-300 px-3 py-1 text-sm text-red-700 hover:bg-red-50"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </div>
+                ))
+              )}
             </div>
           </section>
 
@@ -121,12 +270,8 @@ export default function CourseWorkspacePage() {
               {materials.map((item) => (
                 <div key={item.id} className="rounded-lg border border-zinc-200 p-3">
                   <p className="font-medium text-zinc-900">{item.filename}</p>
-                  <p className="mt-1 text-sm text-zinc-600">
-                    Type: {item.file_type}
-                  </p>
-                  <p className="mt-1 text-xs text-zinc-400">
-                    Status: {item.status}
-                  </p>
+                  <p className="mt-1 text-sm text-zinc-600">Type: {item.file_type}</p>
+                  <p className="mt-1 text-xs text-zinc-400">Status: {item.status}</p>
                 </div>
               ))}
             </div>

--- a/frontend/src/lib/notes-api.ts
+++ b/frontend/src/lib/notes-api.ts
@@ -1,0 +1,96 @@
+// frontend/src/lib/notes-api.ts
+
+const BASE_URL = "http://127.0.0.1:8000";
+
+export type NoteItem = {
+  id: string;
+  course_code: string;
+  title: string;
+  content: string;
+  updated_at: string;
+};
+
+export async function fetchNotesByCourse(courseCode: string): Promise<NoteItem[]> {
+  const response = await fetch(
+    `${BASE_URL}/api/v1/notes/${encodeURIComponent(courseCode)}`
+  );
+
+  if (!response.ok) {
+    throw new Error("Failed to load notes.");
+  }
+
+  const data = await response.json();
+  return data.notes || [];
+}
+
+export async function createNote(courseCode: string, title: string, content: string) {
+  const response = await fetch(`${BASE_URL}/api/v1/notes`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      course_code: courseCode,
+      title,
+      content,
+    }),
+  });
+
+  if (!response.ok) {
+    let message = "Failed to create note.";
+
+    try {
+      const data = await response.json();
+      if (data?.detail) message = data.detail;
+    } catch {}
+
+    throw new Error(message);
+  }
+
+  return response.json();
+}
+
+export async function updateNote(noteId: string, title: string, content: string) {
+  const response = await fetch(`${BASE_URL}/api/v1/notes/${noteId}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      title,
+      content,
+    }),
+  });
+
+  if (!response.ok) {
+    let message = "Failed to update note.";
+
+    try {
+      const data = await response.json();
+      if (data?.detail) message = data.detail;
+    } catch {}
+
+    throw new Error(message);
+  }
+
+  return response.json();
+}
+
+export async function deleteNote(noteId: string) {
+  const response = await fetch(`${BASE_URL}/api/v1/notes/${noteId}`, {
+    method: "DELETE",
+  });
+
+  if (!response.ok) {
+    let message = "Failed to delete note.";
+
+    try {
+      const data = await response.json();
+      if (data?.detail) message = data.detail;
+    } catch {}
+
+    throw new Error(message);
+  }
+
+  return response.json();
+}


### PR DESCRIPTION
## Summary
Implements Day 7A frontend notes module inside the course workspace.

## What was implemented
- added note create form in workspace
- added note list display per course
- added note edit flow
- added note delete flow
- connected notes panel to backend notes API
- kept Day 6 materials and chat panels intact

## What was tested
- create note from UI
- note appears immediately in list
- edit existing note
- delete note
- notes stay linked to selected course
- refresh page still loads saved notes from backend

## CRUD test evidence
- attached screenshots for create, view, edit, and delete flows
- attached browser screenshots showing notes persist after refresh

## Known limitations
- no rich text editor yet
- no search or pinning for notes
- notes are single-panel only for now