### PR TITLE
Fix/day7 course code normalization

### DIFF
--- a/backend/routers/notes.py
+++ b/backend/routers/notes.py
@@ -18,6 +18,8 @@ router = APIRouter(prefix="/api/v1/notes", tags=["Notes"])
 
 NOTES_COLLECTION = "courseNotes"
 
+def normalize_course_code(code: str) -> str:
+    return "".join(code.upper().split())
 
 def now_string():
     return datetime.now().strftime("%Y-%m-%d %I:%M %p")
@@ -25,6 +27,7 @@ def now_string():
 
 @router.get("/{course_code}", response_model=NoteListResponse)
 def get_notes_by_course(course_code: str):
+    course_code = normalize_course_code(course_code)
     notes_ref = db.collection(NOTES_COLLECTION)
     query = notes_ref.where(filter=FieldFilter("course_code", "==", course_code))
     docs = query.stream()
@@ -51,7 +54,7 @@ def get_notes_by_course(course_code: str):
 @router.post("", response_model=NoteSingleResponse)
 def create_note(payload: NoteCreateRequest):
     new_note = {
-        "course_code": payload.course_code.strip(),
+        "course_code": normalize_course_code(payload.course_code),
         "title": payload.title.strip(),
         "content": payload.content.strip(),
         "updated_at": now_string(),
@@ -79,7 +82,7 @@ def update_note(note_id: str, payload: NoteUpdateRequest):
     existing = doc.to_dict()
 
     updated_note = {
-        "course_code": existing["course_code"],
+        "course_code": normalize_course_code(existing["course_code"]),
         "title": payload.title.strip(),
         "content": payload.content.strip(),
         "updated_at": now_string(),

--- a/backend/scripts/normalize_notes.py
+++ b/backend/scripts/normalize_notes.py
@@ -1,0 +1,43 @@
+# backend/scripts/normalize_notes.py
+import sys
+from pathlib import Path
+
+# Add backend directory to path
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from services.firebase_admin_init import db
+
+
+def normalize_course_code(code: str) -> str:
+    return "".join(code.upper().split())
+
+
+def run():
+    print("Starting normalization...")
+
+    docs = db.collection("courseNotes").stream()
+
+    count = 0
+
+    for doc in docs:
+        data = doc.to_dict()
+
+        if "course_code" not in data:
+            continue
+
+        original = data["course_code"]
+        normalized = normalize_course_code(original)
+
+        # Only update if different
+        if original != normalized:
+            doc.reference.update({
+                "course_code": normalized
+            })
+
+            print(f"Updated: {original} → {normalized}")
+            count += 1
+
+    print(f"\nDone. Updated {count} documents.")
+
+
+if __name__ == "__main__":
+    run()

--- a/frontend/src/app/course/[courseId]/page.tsx
+++ b/frontend/src/app/course/[courseId]/page.tsx
@@ -8,13 +8,6 @@ import {
   type NoteItem,
 } from "@/lib/notes-api";
 import {
-  createNote,
-  deleteNote,
-  fetchNotesByCourse,
-  updateNote,
-  type NoteItem,
-} from "../../../lib/notes-api";
-import {
   fetchWorkspaceChat,
   fetchWorkspaceMaterials,
   fetchWorkspaceOverview,

--- a/frontend/src/app/course/[courseId]/page.tsx
+++ b/frontend/src/app/course/[courseId]/page.tsx
@@ -8,6 +8,13 @@ import {
   type NoteItem,
 } from "@/lib/notes-api";
 import {
+  createNote,
+  deleteNote,
+  fetchNotesByCourse,
+  updateNote,
+  type NoteItem,
+} from "../../../lib/notes-api";
+import {
   fetchWorkspaceChat,
   fetchWorkspaceMaterials,
   fetchWorkspaceOverview,

--- a/frontend/src/lib/notes-api.ts
+++ b/frontend/src/lib/notes-api.ts
@@ -1,0 +1,96 @@
+// frontend/src/lib/notes-api.ts
+
+const BASE_URL = "http://127.0.0.1:8000";
+
+export type NoteItem = {
+  id: string;
+  course_code: string;
+  title: string;
+  content: string;
+  updated_at: string;
+};
+
+export async function fetchNotesByCourse(courseCode: string): Promise<NoteItem[]> {
+  const response = await fetch(
+    `${BASE_URL}/api/v1/notes/${encodeURIComponent(courseCode.replace(/\s+/g, "").toUpperCase())}`
+  );
+
+  if (!response.ok) {
+    throw new Error("Failed to load notes.");
+  }
+
+  const data = await response.json();
+  return data.notes || [];
+}
+
+export async function createNote(courseCode: string, title: string, content: string) {
+  const response = await fetch(`${BASE_URL}/api/v1/notes`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      course_code: courseCode.replace(/\s+/g, "").toUpperCase(),
+      title,
+      content,
+    }),
+  });
+
+  if (!response.ok) {
+    let message = "Failed to create note.";
+
+    try {
+      const data = await response.json();
+      if (data?.detail) message = data.detail;
+    } catch {}
+
+    throw new Error(message);
+  }
+
+  return response.json();
+}
+
+export async function updateNote(noteId: string, title: string, content: string) {
+  const response = await fetch(`${BASE_URL}/api/v1/notes/${noteId}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      title,
+      content,
+    }),
+  });
+
+  if (!response.ok) {
+    let message = "Failed to update note.";
+
+    try {
+      const data = await response.json();
+      if (data?.detail) message = data.detail;
+    } catch {}
+
+    throw new Error(message);
+  }
+
+  return response.json();
+}
+
+export async function deleteNote(noteId: string) {
+  const response = await fetch(`${BASE_URL}/api/v1/notes/${noteId}`, {
+    method: "DELETE",
+  });
+
+  if (!response.ok) {
+    let message = "Failed to delete note.";
+
+    try {
+      const data = await response.json();
+      if (data?.detail) message = data.detail;
+    } catch {}
+
+    throw new Error(message);
+  }
+
+  return response.json();
+}

--- a/frontend/src/lib/notes-api.ts
+++ b/frontend/src/lib/notes-api.ts
@@ -10,9 +10,15 @@ export type NoteItem = {
   updated_at: string;
 };
 
+function normalizeCourseCode(courseCode: string): string {
+  return courseCode.replace(/\s+/g, "").toUpperCase();
+}
+
 export async function fetchNotesByCourse(courseCode: string): Promise<NoteItem[]> {
+  const normalizedCourseCode = normalizeCourseCode(courseCode);
+
   const response = await fetch(
-    `${BASE_URL}/api/v1/notes/${encodeURIComponent(courseCode.replace(/\s+/g, "").toUpperCase())}`
+    `${BASE_URL}/api/v1/notes/${encodeURIComponent(normalizedCourseCode)}`
   );
 
   if (!response.ok) {
@@ -24,13 +30,15 @@ export async function fetchNotesByCourse(courseCode: string): Promise<NoteItem[]
 }
 
 export async function createNote(courseCode: string, title: string, content: string) {
+  const normalizedCourseCode = normalizeCourseCode(courseCode);
+
   const response = await fetch(`${BASE_URL}/api/v1/notes`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      course_code: courseCode.replace(/\s+/g, "").toUpperCase(),
+      course_code: normalizedCourseCode,
       title,
       content,
     }),


### PR DESCRIPTION
## Summary
Fixes Day 7 notes integration issues discovered after the notes UI merge.

## Changes
- normalized course code before querying notes in backend
- normalized course code before creating/fetching notes from frontend
- restored the real Day 7 notes workspace page in place of the Day 6 placeholder shell
- added one-time Firestore normalization script for old note data

## Result
- notes now load correctly even when frontend course ids contain spacing or case differences
- old Firestore notes are visible again in the course workspace
- the course page now shows the actual Day 7 note create/edit/delete UI instead of the Day 6 placeholder panel