### PR TITLE
feat: add course material upload backend with cloudinary and firestore

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -6,7 +6,14 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
-    debug: bool = True
+    app_name: str = "System Project Backend"
+    debug: bool = False
+
+    cloudinary_cloud_name: str | None = None
+    cloudinary_api_key: str | None = None
+    cloudinary_api_secret: str | None = None
+
+    #debug: bool = True
     host: str = "127.0.0.1"
     port: int = 8000
     upload_dir: str = "uploads/routines"

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 from routers import workspace
 from routers import notes
+from routers import materials
 from fastapi.middleware.cors import CORSMiddleware
 
 from config import get_settings
@@ -45,3 +46,4 @@ app.include_router(routine_router)
 app.include_router(courses_router)
 app.include_router(workspace.router)
 app.include_router(notes.router)
+app.include_router(materials.router)

--- a/backend/models/materials.py
+++ b/backend/models/materials.py
@@ -1,0 +1,28 @@
+# backend/models/materials.py
+
+from pydantic import BaseModel
+from typing import List
+
+
+class MaterialItem(BaseModel):
+    id: str
+    course_code: str
+    title: str
+    file_type: str
+    content_type: str
+    uploaded_at: str
+    status: str
+    file_size_bytes: int
+    file_url: str
+    public_id: str
+
+
+class MaterialListResponse(BaseModel):
+    success: bool = True
+    course_code: str
+    materials: List[MaterialItem]
+
+
+class MaterialUploadResponse(BaseModel):
+    success: bool = True
+    material: MaterialItem

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,4 @@ pytesseract==0.3.13
 opencv-python==4.10.0.84
 numpy==2.1.1
 firebase-admin
+google-cloud-storage

--- a/backend/routers/materials.py
+++ b/backend/routers/materials.py
@@ -1,112 +1,179 @@
 # backend/routers/materials.py
 
 from datetime import datetime
+import mimetypes
+import os
+import tempfile
 
-from fastapi import APIRouter, File, UploadFile
+import cloudinary.uploader
+import requests
+from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi.responses import FileResponse
 from google.cloud.firestore_v1.base_query import FieldFilter
 
-from models.materials import MaterialListResponse, MaterialUploadResponse
 from services.firebase_admin_init import db
-from services.material_storage import (
-    normalize_course_code,
-    upload_file_to_cloudinary,
-    validate_material_file,
-)
-import cloudinary.uploader
+from services.material_storage import upload_file_to_cloudinary
 
 router = APIRouter(prefix="/api/v1/materials", tags=["Materials"])
 
-MATERIALS_COLLECTION = "courseMaterials"
+COLLECTION = "courseMaterials"
 
 
-def now_string() -> str:
+def normalize_course_code(code: str) -> str:
+    return "".join(code.upper().split())
+
+
+def now_string():
     return datetime.now().strftime("%Y-%m-%d %I:%M %p")
 
 
-@router.post("/upload/{course_code}", response_model=MaterialUploadResponse)
+@router.post("/upload")
 def upload_material(course_code: str, file: UploadFile = File(...)):
-    normalized_course_code = normalize_course_code(course_code)
+    if not file.filename:
+        raise HTTPException(status_code=400, detail="Invalid file.")
 
-    validate_material_file(file)
-    uploaded = upload_file_to_cloudinary(normalized_course_code, file)
+    normalized_code = normalize_course_code(course_code)
 
-    material_doc = {
-        "course_code": uploaded["course_code"],
-        "title": uploaded["title"],
-        "file_type": uploaded["file_type"],
-        "content_type": uploaded["content_type"],
+    try:
+        result = upload_file_to_cloudinary(normalized_code, file)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    new_doc = {
+        "course_code": normalized_code,
+        "filename": file.filename,
+        "file_url": result["file_url"],
+        "public_id": result["public_id"],
         "uploaded_at": now_string(),
-        "status": "uploaded",
-        "file_size_bytes": uploaded["file_size_bytes"],
-        "file_url": uploaded["file_url"],
-        "public_id": uploaded["public_id"],
     }
 
-    doc_ref = db.collection(MATERIALS_COLLECTION).document()
-    doc_ref.set(material_doc)
+    doc_ref = db.collection(COLLECTION).document()
+    doc_ref.set(new_doc)
 
-    return MaterialUploadResponse(
-        material={
-            "id": doc_ref.id,
-            "course_code": material_doc["course_code"],
-            "title": material_doc["title"],
-            "file_type": material_doc["file_type"],
-            "content_type": material_doc["content_type"],
-            "uploaded_at": material_doc["uploaded_at"],
-            "status": material_doc["status"],
-            "file_size_bytes": material_doc["file_size_bytes"],
-            "file_url": material_doc["file_url"],
-            "public_id": material_doc["public_id"],
-        }
+    return {
+        "id": doc_ref.id,
+        **new_doc
+    }
+
+
+@router.get("/{course_code}")
+def get_materials(course_code: str):
+    normalized_code = normalize_course_code(course_code)
+
+    docs = (
+        db.collection(COLLECTION)
+        .where(filter=FieldFilter("course_code", "==", normalized_code))
+        .stream()
     )
-
-
-@router.get("/{course_code}", response_model=MaterialListResponse)
-def get_materials_by_course(course_code: str):
-    normalized_course_code = normalize_course_code(course_code)
-
-    query = db.collection(MATERIALS_COLLECTION).where(
-        filter=FieldFilter("course_code", "==", normalized_course_code)
-    )
-    docs = query.stream()
 
     materials = []
     for doc in docs:
         data = doc.to_dict()
         materials.append({
             "id": doc.id,
-            "course_code": data["course_code"],
-            "title": data["title"],
-            "file_type": data["file_type"],
-            "content_type": data["content_type"],
-            "uploaded_at": data["uploaded_at"],
-            "status": data["status"],
-            "file_size_bytes": data["file_size_bytes"],
+            "filename": data["filename"],
             "file_url": data["file_url"],
-            "public_id": data["public_id"],
+            "uploaded_at": data["uploaded_at"],
         })
 
-    materials.sort(key=lambda x: x["uploaded_at"], reverse=True)
+    return {"materials": materials}
 
-    return MaterialListResponse(
-        course_code=normalized_course_code,
-        materials=materials,
-    )
 
-@router.delete("/{material_id}")
-def delete_material(material_id: str):
-    doc_ref = db.collection("courseMaterials").document(material_id)
+@router.get("/preview/{material_id}")
+def preview_material(material_id: str):
+    doc_ref = db.collection(COLLECTION).document(material_id)
     doc = doc_ref.get()
 
     if not doc.exists:
-        raise HTTPException(status_code=404, detail="Material not found")
+        raise HTTPException(status_code=404, detail="Material not found.")
+
+    data = doc.to_dict()
+    file_url = data["file_url"]
+    filename = data["filename"]
+
+    response = requests.get(file_url, timeout=30)
+    if response.status_code != 200:
+        raise HTTPException(status_code=502, detail="Failed to fetch file from Cloudinary.")
+
+    suffix = os.path.splitext(filename)[1]
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
+    tmp.write(response.content)
+    tmp.close()
+
+    media_type, _ = mimetypes.guess_type(filename)
+    if not media_type:
+        media_type = "application/octet-stream"
+
+    return FileResponse(
+        path=tmp.name,
+        media_type=media_type,
+        filename=filename,
+        headers={"Content-Disposition": f'inline; filename="{filename}"'},
+    )
+
+
+@router.get("/download/{material_id}")
+def download_material(material_id: str):
+    doc_ref = db.collection(COLLECTION).document(material_id)
+    doc = doc_ref.get()
+
+    if not doc.exists:
+        raise HTTPException(status_code=404, detail="Material not found.")
+
+    data = doc.to_dict()
+    file_url = data["file_url"]
+    filename = data["filename"]
+
+    response = requests.get(file_url, timeout=30)
+    if response.status_code != 200:
+        raise HTTPException(status_code=502, detail="Failed to fetch file from Cloudinary.")
+
+    suffix = os.path.splitext(filename)[1]
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
+    tmp.write(response.content)
+    tmp.close()
+
+    media_type, _ = mimetypes.guess_type(filename)
+    if not media_type:
+        media_type = "application/octet-stream"
+
+    return FileResponse(
+        path=tmp.name,
+        media_type=media_type,
+        filename=filename,
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@router.delete("/{material_id}")
+def delete_material(material_id: str):
+    doc_ref = db.collection(COLLECTION).document(material_id)
+    doc = doc_ref.get()
+
+    if not doc.exists:
+        raise HTTPException(status_code=404, detail="Material not found.")
 
     data = doc.to_dict()
     public_id = data.get("public_id")
 
-    if public_id:
-        cloudinary.uploader.destroy(public_id)
+    try:
+        if public_id:
+            destroy_result = cloudinary.uploader.destroy(
+                public_id,
+                resource_type="raw",
+                invalidate=True,
+            )
+
+            if destroy_result.get("result") not in {"ok", "not found"}:
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Cloudinary delete failed: {destroy_result}"
+                )
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Cloudinary delete failed: {str(e)}")
 
     doc_ref.delete()
 
-    return {"message": "Deleted successfully"}
+    return {"message": "Material deleted successfully"}

--- a/backend/routers/materials.py
+++ b/backend/routers/materials.py
@@ -1,0 +1,112 @@
+# backend/routers/materials.py
+
+from datetime import datetime
+
+from fastapi import APIRouter, File, UploadFile
+from google.cloud.firestore_v1.base_query import FieldFilter
+
+from models.materials import MaterialListResponse, MaterialUploadResponse
+from services.firebase_admin_init import db
+from services.material_storage import (
+    normalize_course_code,
+    upload_file_to_cloudinary,
+    validate_material_file,
+)
+import cloudinary.uploader
+
+router = APIRouter(prefix="/api/v1/materials", tags=["Materials"])
+
+MATERIALS_COLLECTION = "courseMaterials"
+
+
+def now_string() -> str:
+    return datetime.now().strftime("%Y-%m-%d %I:%M %p")
+
+
+@router.post("/upload/{course_code}", response_model=MaterialUploadResponse)
+def upload_material(course_code: str, file: UploadFile = File(...)):
+    normalized_course_code = normalize_course_code(course_code)
+
+    validate_material_file(file)
+    uploaded = upload_file_to_cloudinary(normalized_course_code, file)
+
+    material_doc = {
+        "course_code": uploaded["course_code"],
+        "title": uploaded["title"],
+        "file_type": uploaded["file_type"],
+        "content_type": uploaded["content_type"],
+        "uploaded_at": now_string(),
+        "status": "uploaded",
+        "file_size_bytes": uploaded["file_size_bytes"],
+        "file_url": uploaded["file_url"],
+        "public_id": uploaded["public_id"],
+    }
+
+    doc_ref = db.collection(MATERIALS_COLLECTION).document()
+    doc_ref.set(material_doc)
+
+    return MaterialUploadResponse(
+        material={
+            "id": doc_ref.id,
+            "course_code": material_doc["course_code"],
+            "title": material_doc["title"],
+            "file_type": material_doc["file_type"],
+            "content_type": material_doc["content_type"],
+            "uploaded_at": material_doc["uploaded_at"],
+            "status": material_doc["status"],
+            "file_size_bytes": material_doc["file_size_bytes"],
+            "file_url": material_doc["file_url"],
+            "public_id": material_doc["public_id"],
+        }
+    )
+
+
+@router.get("/{course_code}", response_model=MaterialListResponse)
+def get_materials_by_course(course_code: str):
+    normalized_course_code = normalize_course_code(course_code)
+
+    query = db.collection(MATERIALS_COLLECTION).where(
+        filter=FieldFilter("course_code", "==", normalized_course_code)
+    )
+    docs = query.stream()
+
+    materials = []
+    for doc in docs:
+        data = doc.to_dict()
+        materials.append({
+            "id": doc.id,
+            "course_code": data["course_code"],
+            "title": data["title"],
+            "file_type": data["file_type"],
+            "content_type": data["content_type"],
+            "uploaded_at": data["uploaded_at"],
+            "status": data["status"],
+            "file_size_bytes": data["file_size_bytes"],
+            "file_url": data["file_url"],
+            "public_id": data["public_id"],
+        })
+
+    materials.sort(key=lambda x: x["uploaded_at"], reverse=True)
+
+    return MaterialListResponse(
+        course_code=normalized_course_code,
+        materials=materials,
+    )
+
+@router.delete("/{material_id}")
+def delete_material(material_id: str):
+    doc_ref = db.collection("courseMaterials").document(material_id)
+    doc = doc_ref.get()
+
+    if not doc.exists:
+        raise HTTPException(status_code=404, detail="Material not found")
+
+    data = doc.to_dict()
+    public_id = data.get("public_id")
+
+    if public_id:
+        cloudinary.uploader.destroy(public_id)
+
+    doc_ref.delete()
+
+    return {"message": "Deleted successfully"}

--- a/backend/services/cloudinary_init.py
+++ b/backend/services/cloudinary_init.py
@@ -1,0 +1,19 @@
+# backend/services/cloudinary_init.py
+
+import cloudinary
+from config import get_settings
+
+settings = get_settings()
+
+print("Cloudinary Config Debug:", {
+    "cloud_name": settings.cloudinary_cloud_name,
+    "api_key": settings.cloudinary_api_key,
+    "api_secret_exists": settings.cloudinary_api_secret is not None,
+})
+
+cloudinary.config(
+    cloud_name=settings.cloudinary_cloud_name,
+    api_key=settings.cloudinary_api_key,
+    api_secret=settings.cloudinary_api_secret,
+    secure=True,
+)

--- a/backend/services/material_storage.py
+++ b/backend/services/material_storage.py
@@ -1,0 +1,72 @@
+# backend/services/material_storage.py
+
+import uuid
+from pathlib import Path
+
+import cloudinary.uploader
+from fastapi import HTTPException, UploadFile
+
+from services.cloudinary_init import cloudinary
+
+
+ALLOWED_EXTENSIONS = {".pdf", ".docx", ".pptx"}
+ALLOWED_CONTENT_TYPES = {
+    "application/pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+}
+
+
+def normalize_course_code(code: str) -> str:
+    return "".join(ch for ch in code.upper() if ch.isalnum())
+
+
+def get_extension(filename: str) -> str:
+    return Path(filename).suffix.lower()
+
+
+def validate_material_file(file: UploadFile):
+    extension = get_extension(file.filename or "")
+
+    if extension not in ALLOWED_EXTENSIONS:
+        raise HTTPException(
+            status_code=400,
+            detail="Unsupported file type. Only PDF, DOCX, and PPTX are allowed.",
+        )
+
+    if file.content_type and file.content_type not in ALLOWED_CONTENT_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid content type for uploaded material.",
+        )
+
+
+def upload_file_to_cloudinary(course_code: str, file: UploadFile):
+    normalized_course_code = normalize_course_code(course_code)
+    extension = get_extension(file.filename or "")
+    filename_stem = Path(file.filename or "file").stem
+    unique_suffix = uuid.uuid4().hex[:10]
+    public_id = f"{normalized_course_code}_{filename_stem}_{unique_suffix}"
+
+    file.file.seek(0, 2)
+    file_size = file.file.tell()
+    file.file.seek(0)
+
+    result = cloudinary.uploader.upload(
+        file.file,
+        resource_type="raw",
+        folder=f"course-materials/{normalized_course_code}",
+        public_id=public_id,
+        use_filename=False,
+        overwrite=False,
+    )
+
+    return {
+        "course_code": normalized_course_code,
+        "title": file.filename or public_id + extension,
+        "file_type": extension.replace(".", "").upper(),
+        "content_type": file.content_type or "application/octet-stream",
+        "file_size_bytes": file_size,
+        "file_url": result["secure_url"],
+        "public_id": result["public_id"],
+    }


### PR DESCRIPTION
## Summary
This PR implements the backend system for course materials, enabling upload, retrieval, preview, download, and deletion with persistent Cloudinary storage and Firestore metadata.

---

## What was implemented

### Backend — Materials Storage System
- Added course materials upload API
- Integrated Cloudinary for persistent file storage
- Stored course material metadata in Firestore
- Linked uploaded files to normalized course codes

### File Retrieval
- Added course-based materials fetch endpoint
- Added preview endpoint for inline browser opening
- Added download endpoint for attachment delivery

### File Deletion
- Added materials delete endpoint
- Removed Firestore metadata on delete
- Attempted Cloudinary file cleanup using stored `public_id`

### System Integration
- Registered materials router in backend
- Connected materials service layer with router logic

---

## What was tested
- upload endpoint stores file in Cloudinary
- metadata is stored in Firestore
- materials can be fetched per course
- preview opens in browser through backend endpoint
- download triggers attachment response
- delete removes material metadata

---

## Scope
This PR covers:
- Day 8B: Backend materials system with cloud storage and file delivery support